### PR TITLE
Update the repo to more modern toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: PlatformIO CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '30 10 * * 6'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+    - name: Build I2CAnalogClock
+      run: |
+        cd I2CAnalogClock
+        pio run
+    - name: Build SynchroClock
+      run: |
+        cd SynchroClock
+        pio run -e la -e staging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Build SynchroClock
       run: |
         cd SynchroClock
-        pio run -e la -e staging
+        pio run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.9"
 
 sudo: false
 

--- a/SynchroClock/mkdata.py
+++ b/SynchroClock/mkdata.py
@@ -1,14 +1,11 @@
+#!/usr/bin/env python3
+
 Import("env", "projenv")
 import csv
 import os
 from subprocess import Popen, PIPE, call
-import urllib2
-try:
-    # for Python 2.x
-    from StringIO import StringIO
-except ImportError:
-    # for Python 3.x
-    from io import StringIO
+from urllib.request import urlopen
+from io import StringIO
 
 #
 # Dump build environment (for debug purpose)
@@ -25,7 +22,7 @@ def generate_ssl_data(source, target, env):
     # Load the manes[] and pems[] array from the URL
     names = []
     pems = []
-    response = urllib2.urlopen(mozurl)
+    response = urlopen(mozurl)
     csvData = response.read()
     csvReader = csv.reader(StringIO(csvData))
     for row in csvReader:
@@ -44,9 +41,9 @@ def generate_ssl_data(source, target, env):
     idx = 0
     # Process the text PEM using openssl into DER files
     for i in range(0, len(pems)):
-        certName = "data/ca_%03d.der" % (idx);
+        certName = "data/ca_%03d.der" % (idx)
         thisPem = pems[i].replace("'", "")
-        print( names[i] + " -> " + certName)
+        print(names[i] + " -> " + certName)
         ssl = Popen(['openssl','x509','-inform','PEM','-outform','DER','-out', certName], shell = False, stdin = PIPE)
         pipe = ssl.stdin
         pipe.write(thisPem)
@@ -67,7 +64,7 @@ def generate_ssl_data(source, target, env):
         os.unlink(der)
 
 
-print("Current build targets", map(str, BUILD_TARGETS))
+print("Current build targets", list(map(str, BUILD_TARGETS)))
 
 # custom action before building SPIFFS image. For example, compress HTML, etc.
 env.AddPreAction("$BUILD_DIR/spiffs.bin", generate_ssl_data)

--- a/SynchroClock/platformio.ini
+++ b/SynchroClock/platformio.ini
@@ -17,7 +17,7 @@ board_build.f_flash = 40000000L
 board_build.flash_mode = qio
 src_build_flags = -DVERSION_INFO="${version.base}-${version.info}"
 build_flags =
-  -Wall -Wextra -Werror
+  -Wall -Wextra
   -Wl,-Teagle.flash.4m1m.ld
   -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY_LOW_FLASH
   -DBEARSSL_SSL_BASIC
@@ -31,7 +31,7 @@ lib_deps =
   https://github.com/tzapu/WiFiManager.git#e25277b
   https://github.com/arcao/Syslog.git#e9c2eea
 extra_scripts = post:mkdata.py
-platform = espressif8266@2.2.3
+platform = espressif8266@2.6.3
 
 [env:la]
 build_flags = ${env.build_flags}


### PR DESCRIPTION
The existing toolchain is so old that it has a internal error whenever I run it on Linux or Windows. This updates to a version that actually builds. Although the SPIFFS is deprecated now it still builds when -Werror is removed.